### PR TITLE
Add Scripture Linking to Mobile Drawer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# This file is for unifying the coding style for different editors and IDEs.
+# More information at http://EditorConfig.org
+
+# No .editorconfig files above the root directory
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_size = 2

--- a/frontend/webapp/src/views/Home/ReadingPlan.js
+++ b/frontend/webapp/src/views/Home/ReadingPlan.js
@@ -66,7 +66,7 @@ export function ReadingPlan({appController,slug}){
     if(planData) planData.progress = averageProgress || 0;
     function getProgressStatus(progressInt) {
         let status = {};
-        
+
         if (progressInt > 95 || nonFutureSegments?.length === 1 || pastSegmentsAreComplete) {
             status = { label: label("status_ontrack"), labelClass: "green" };
         } else if (progressInt === 0) {
@@ -83,7 +83,7 @@ export function ReadingPlan({appController,slug}){
 // Usage
 const { label:labelText, labelClass } = getProgressStatus(progressInt);
 
- 
+
     if(!planData) return <ReadingPlanLoading />;
     return (
         <Card className="noselect">
@@ -101,7 +101,7 @@ const { label:labelText, labelClass } = getProgressStatus(progressInt);
             </CardHeader>
             <CardBody>
                 <ReactTooltip place="top" effect="solid" id={`segmentTips`} />
-                <ReadingPlanSegmentList segments={planData.segments} 
+                <ReadingPlanSegmentList segments={planData.segments}
                 today={today}
                 setActiveSegment={setActiveSegment} activeSegment={activeSegment} />
             </CardBody>
@@ -257,7 +257,7 @@ function ReadingPlanSection({section}){
             data-for={`sectionDotTips-${slug}`}
             data-tip={item.heading}
             src={ item.status === "completed" ? green : item.status === "started" ? yellow : blank} />
-            
+
             )}
             </div>
         </div>
@@ -272,7 +272,7 @@ function ReadingPlanLoading(){
         <h3>{label("reading_plan")}: <span className="planName">{label("loading")}</span></h3>
     </CardHeader>
     <CardBody className="spinnerBox segment" style={{border: "none"}}>
-        <img src={loading} style={{height: "4rem"}}/>        
+        <img src={loading} style={{height: "4rem"}}/>
     </CardBody>
     </Card>
 }

--- a/frontend/webapp/src/views/Page/Narration.js
+++ b/frontend/webapp/src/views/Page/Narration.js
@@ -16,6 +16,7 @@ import {Spinner} from "../_Common/Loader";
 import { determineLanguage } from "../../models/Utils";
 import { Link } from "react-router-dom";
 import ReactTooltip from "react-tooltip";
+import classNames from "classnames";
 const {generateReference, detectReferences, setLang, lookupReference} = require('scripture-guide');
 
 function ChronoRow({ chrono }) {
@@ -688,7 +689,7 @@ function PeoplePlacePanel({ narrationController }) {
         <span onClick={closePanel}> × </span>
       </h5>
     <div className="peoplePlacePanel">
-      
+
       {items.map((item)=> {
         return <div key={item.name} className="item" onClick={()=>popUpPerson(item.slug,item.type)}>
 
@@ -697,7 +698,7 @@ function PeoplePlacePanel({ narrationController }) {
           </div>
           <img src={`${assetUrl}/${item.type}/${item.slug}`} alt={item.name} />
           <div className="info">{(item.title || item.info).replace(/[1-4]/g, replaceNumbers)}</div>
-          
+
             </div>;
       })}
     </div>
@@ -831,15 +832,15 @@ function ScripturePanel({ narrationController }) {
           break;
       }
     };
-  
+
     window.addEventListener('keydown', handleKeyDown);
-  
+
     // Cleanup: remove the event listener when the component is unmounted
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
 
-    
+
   }, [activeRef]); // Re-run the effect when activeRef changes
 
   if(!refs?.length) return null;
@@ -860,18 +861,19 @@ function ScripturePanel({ narrationController }) {
   </div>
 }
 
-export function ScripturePanelSingle({ scriptureData,closeButton, setPopUpRef }) {
-
+export function ScripturePanelSingle({ scriptureData, closeButton, onClose, setPopUpRef }) {
   const {ref} = scriptureData || {ref:null,verse_id:null};
   const [passages, setPassages] = useState([]);
-  
-  const closeButtonEl = !!closeButton ? <div className="closebutton"
-  onClick={()=>{
-    setPopUpRef(null)
-    setPassages([]);
-  }}
-  >×</div> :null;
 
+  const closeButtonEl = !!closeButton ? (
+    <div className="closebutton"
+      onClick={()=>{
+        onClose?.();
+        setPopUpRef?.(null)
+        setPassages([]);
+      }}
+    >×</div>
+  ) : null;
 
   useEffect(() => {
     if(!ref) return false;
@@ -885,42 +887,45 @@ export function ScripturePanelSingle({ scriptureData,closeButton, setPopUpRef })
 
   }, [ref]);
 
-
-
-
-  const scripturePassages = passages.map(({reference,heading,verses})=>{
+  const scripturePassages = passages.map(({reference, heading, verses}, index)=>{
     const h6Content = (passages.length > 1 ? `${reference}—` : '') + heading ;
     //between 31103 and 37706 is the BoM
     const verse_ids = lookupReference(reference).verse_ids;
     const [verse_id] = verse_ids;
-    const isBoM = verse_id >= 31103 && verse_id <= 37706; 
+    const isBoM = verse_id >= 31103 && verse_id <= 37706;
 
-  const buttons = <div className="buttons">
-  {isBoM && <Link to={`/search/${reference.replace(/\s+/g,".").toLowerCase()}`} >
-  <button className="btn btn-sm btn-outline-secondary" >Study</button>
-  </Link>
-  }
-</div>
-
-
-    return <div className="text">
-      <div className="scriptureTextHeader">
-      {h6Content && <h6>{h6Content}</h6>}
-      {buttons}
+    const buttons = (
+      <div className="buttons">
+        {isBoM && (
+          <Link to={`/search/${reference.replace(/\s+/g,".").toLowerCase()}`} >
+            <button className="btn btn-sm btn-outline-secondary" >Study</button>
+          </Link>
+        )}
       </div>
+    );
+
+    return (
+      <div key={index} className="text">
+        <div className="scriptureTextHeader">
+          {h6Content && <h6>{h6Content}</h6>}
+          {buttons}
+        </div>
         <p>{verses.map(v=>v.text).join(" ")}</p>
-    </div>});
+      </div>
+    )
+  });
 
 
   if(!ref) return null;
 
-  return <div className="scripturePanelSingle">
-    <h5>{ref}{closeButtonEl}</h5>
-    <div className="scripturePassages">
-   {passages.length ? scripturePassages : <Spinner/>}
-   </div>
-  </div>
-
+  return (
+    <div className="scripturePanelSingle px-0">
+      <h5 className="m-0">{ref}{closeButtonEl}</h5>
+      <div className="scripturePassages p-0 pt-2 pb-4">
+        {passages.length ? scripturePassages : <Spinner/>}
+      </div>
+    </div>
+  );
 }
 
 function FacsimilePanel({ narrationController }) {

--- a/frontend/webapp/src/views/Page/PersonPlace.js
+++ b/frontend/webapp/src/views/Page/PersonPlace.js
@@ -1,10 +1,10 @@
 import React from "react";
-import parse from "html-react-parser";
+import Parser from "html-react-parser";
 import ReactTooltip from "react-tooltip";
 import { Link } from "react-router-dom";
 import { assetUrl } from "src/models/BoMOnlineAPI";
 
-export const renderPersonPlaceHTML = (html, pageController,setPopupRef) => {
+export const renderPersonPlaceHTML = (html, pageController, scriptureLinkClickHandler) => {
   html = html.replace(
     /{(.*?)\|(.*?)}/g,
     "<a class='person' slug='$2' label='$1'></a>",
@@ -24,9 +24,10 @@ export const renderPersonPlaceHTML = (html, pageController,setPopupRef) => {
       const attribs = { ...domNode.attribs };
       if (attribs?.classname === 'scripture_link') {
         const ref = domNode.children[0].data;
-        attribs.class = attribs.classname;
+        // TODO: figure out why not a regular class here insead of className (reparsed?)
+        attribs.className = attribs.classname;
         delete attribs.classname;
-        return <a {...attribs} onClick={()=>setPopupRef(ref)}>{ref}</a>;
+        return <a {...attribs} onClick={()=>scriptureLinkClickHandler(ref)}>{ref}</a>;
       }
 
       if (domNode.attribs && domNode.attribs.class === "person") {
@@ -80,7 +81,7 @@ export const renderPersonPlaceHTML = (html, pageController,setPopupRef) => {
       }
     },
   };
-  return parse(html, options);
+  return Parser(html, options);
 };
 
 function PersonLink({ label, id, pageController }) {

--- a/frontend/webapp/src/views/Welcome/pages/showcase.js
+++ b/frontend/webapp/src/views/Welcome/pages/showcase.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import { HomeFeed } from "../../Home/Feed"; 
+import { HomeFeed } from "../../Home/Feed";
 import { Button, Card, CardBody, CardFooter, CardHeader } from "reactstrap";
 import BoMOnlineAPI, { assetUrl } from 'src/models/BoMOnlineAPI';
 import { Link ,useHistory} from "react-router-dom/cjs/react-router-dom.min";
@@ -18,7 +18,7 @@ export default function WelcomeUnShaken({appController})
             <CommunityFeed appController={appController} />
         </div>
     </div>
-            
+
 }
 
 function HeroBanner()
@@ -120,19 +120,19 @@ function ShowCasePanel({title, video, link, isActive})
     const history = useHistory();
 
     return <Card className={`showcase-panel ${isActive ? "active" : ""}`} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
-        <CardHeader className="showcase-panel-header" display="flex" justifycontent="space-between">
+        <CardHeader className="showcase-panel-header" display="flex" style={{justifyContent: 'space-between'}}>
             <h6>{title} </h6>
         </CardHeader>
         <CardBody className="showcase-panel-body">
-        <video 
+        <video
 			id={`video-${video}`}
-            style={{  
+            style={{
                  objectFit: 'cover',
                  objectPosition: 'top center',
 
-                }} 
-            loop 
-            muted   
+                }}
+            loop
+            muted
             playsInline={true}
             src={`${assetUrl}/video/welcome/${video || "skim"}`}
         />

--- a/frontend/webapp/src/views/Welcome/pages/unshaken.js
+++ b/frontend/webapp/src/views/Welcome/pages/unshaken.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import { HomeFeed } from "../../Home/Feed"; 
+import { HomeFeed } from "../../Home/Feed";
 import { Button, Card, CardBody, CardFooter, CardHeader } from "reactstrap";
 import BoMOnlineAPI, { assetUrl } from 'src/models/BoMOnlineAPI';
 import { Link ,useHistory} from "react-router-dom/cjs/react-router-dom.min";
@@ -17,7 +17,7 @@ export default function WelcomeUnShaken({appController})
             <CommunityFeed groupId={groupId} appController={appController} />
         </div>
     </div>
-            
+
 }
 
 function HeroBanner()
@@ -48,7 +48,7 @@ function CommunityFeed({groupId, appController})
             </CardHeader>
             <CardBody style={{textAlign: 'center'}}>
                 Here are the latest insights from Jared’s study group. Join the group to add your own comments and insights.
-           
+
             </CardBody>
         </Card>
         <HomeFeed appController={appController} activeGroup={groupId} />
@@ -131,19 +131,19 @@ function ShowCasePanel({title, video, link, isActive})
     const history = useHistory();
 
     return <Card className={`showcase-panel ${isActive ? "active" : ""}`} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onClick={onClick}>
-        <CardHeader className="showcase-panel-header" display="flex" justifycontent="space-between">
+        <CardHeader className="showcase-panel-header" display="flex" style={{justifyContent: 'space-between'}}>
             <h6>{title} </h6>
         </CardHeader>
         <CardBody className="showcase-panel-body">
-        <video 
+        <video
 						id={`video-${video}`}
-            style={{  
+            style={{
                  objectFit: 'cover',
                  objectPosition: 'top center',
 
-                }} 
-            loop 
-            muted   
+                }}
+            loop
+            muted
             src={`${assetUrl}/video/welcome/${video || "skim"}`}
         />
         </CardBody>

--- a/frontend/webapp/src/views/_Common/BottomNav.css
+++ b/frontend/webapp/src/views/_Common/BottomNav.css
@@ -2,8 +2,8 @@
 .bottom-nav
 {
     display: none;
-    -webkit-box-shadow: 0px 0px 28px 3px rgba(0,0,0,0.77); 
-    box-shadow: 0px 0px 28px 3px rgba(0,0,0,0.77);
+    -webkit-box-shadow: 0px 0px 28px 3px rgba(0,0,0,0.4);
+    box-shadow: 0px 0px 28px 3px rgba(0,0,0,0.4);
     margin-top: -2px;
     z-index: 400;
     position: fixed;

--- a/frontend/webapp/src/views/_Common/Commentary.js
+++ b/frontend/webapp/src/views/_Common/Commentary.js
@@ -13,7 +13,7 @@ import { ScripturePanelSingle } from "../Page/Narration";
 import { setLanguage, detectScriptures } from "scripture-guide";
 import { determineLanguage } from "../../models/Utils";
 import { ATVHeader } from "./ATV";
-//
+import { getHtmlScriptureLinkParserOptions } from "./ViewUtils";
 
 export default function Commentary({ appController }) {
 
@@ -187,18 +187,7 @@ export default function Commentary({ appController }) {
     return `<a className="scripture_link">${scripture}</a>`
   });
 
-  const parseOptions = {
-    replace: (domNode) => {
-      const attribs = { ...domNode.attribs };
-      if (attribs?.classname === 'scripture_link') {
-        const ref = domNode.children[0].data;
-        attribs.class = attribs.classname;
-        delete attribs.classname;
-        return <a {...attribs} onClick={()=>setPopUpRef(ref)}>{ref}</a>;
-      }
-    }
-  }
-
+  const parserOptions = getHtmlScriptureLinkParserOptions((ref) => setPopUpRef(ref));
 
   return (
     <>
@@ -271,7 +260,7 @@ export default function Commentary({ appController }) {
                   />
 
                   <ATVHeader atvHTML={atvHTML} />
-                  {Parser(htmlObject, parseOptions)}
+                  {Parser(htmlObject, parserOptions)}
                 </div>
               </div>
             </div>

--- a/frontend/webapp/src/views/_Common/Drawer.css
+++ b/frontend/webapp/src/views/_Common/Drawer.css
@@ -5,38 +5,31 @@
     background: white;
     font-size: 1.6rem;
     z-index: 15;
-    height: calc(100vh - 60px);
+    height: calc(100vh - 60px - 64px) !important;
+    top: 60px !important;
     will-change: transform;
     transform: translate3d(0, 0, 0);
-    overflow-y: auto;
-
     width: 90%;
-    height: 100vh;
-    padding: 1em;
-    padding-top: calc(60px + 1ex);
-    padding-bottom: 30vh;
-  }
-   
+}
 
-  .popupDrawer h3,
-  .popupDrawer h4{
+.popupDrawer .subject {
+  min-height: calc(55vh - 60px - 64px);
+}
+
+.popupDrawer h3,
+.popupDrawer h4 {
     font-size: 1.5rem;
     font-weight: bold;
     margin: 0;
-    padding-top: 1ex;
+    padding-top: 1.8ex;
 }
 .popupDrawer h3
 {
-
     border-top: 1px solid #AAA;
     margin-bottom: 1ex;
     line-height: 1em;
 }
 
-.popupDrawer #bodytext{
-
-    font-size: .9rem;
-}
 .popupDrawer .source
 {
     width: 100%;
@@ -49,8 +42,8 @@
     object-fit: cover;
     margin-right: 1ex;
     border: 2px solid #666;
-    flex-shrink: 0; 
-    align-self: flex-start;  
+    flex-shrink: 0;
+    align-self: flex-start;
 }
 .popupDrawer .source > div{
     display: flex;
@@ -63,6 +56,21 @@
 .popupDrawer .source h5{
     font-weight: bold;
     font-size: 1rem;
+}
+
+.popupDrawer .container {
+  margin-bottom: 1ex;
+  padding-top: 0;
+  min-height: auto;
+}
+
+.popupDrawer .container #bodytext {
+  padding: 0;
+  font-size: .9rem;
+}
+
+.popupDrawer .scripturePassages {
+  max-height: calc(50vh - 60px - 64px);
 }
 
 .popupDrawer .topTabs
@@ -121,7 +129,7 @@
   .popupDrawer .pagePerc.hide {
     opacity: 0;
   }
-  
+
   .popupDrawer .sectionBox
   {
     line-height: 1.5rem;
@@ -134,25 +142,25 @@
     word-break: break-all;
     line-height: 1rem;
   }
-  
-  
+
+
   .popupDrawer .sectionDots span img {
     border:0;
     height: 1.5rem;
     width: 1.5rem;
     margin-right: -.3rem;
   }
-  .popupDrawer .sectionDots a:last-child span img 
+  .popupDrawer .sectionDots a:last-child span img
   {
     margin-right: 0;
   }
-  
-  
-  
+
+
+
   .ProgressBox .divProgress {
     margin-bottom: 2em;
   }
-  
+
   .popupDrawer .sectionDots:last-child {
     border: none;
   }
@@ -171,7 +179,6 @@
   {
     font-size: 1rem;
     line-height: 1rem;
-    padding-right: 1em;
     text-align: justify;
     font-weight: 400;
     color: #333;
@@ -182,13 +189,18 @@
     display: flex;
   }
 
+  .pDrawerHeaderBox h3,
+  .pDrawerHeaderBox h4 {
+    border: none;
+  }
   .pDrawerHeaderBox img{
     flex-shrink: 0;align-self: center;
     flex: 0 0 auto;
-    margin: 1ex;
+    margin: 1ex 0 1ex 1ex;
     border: 1px solid #000A;
     max-width: 30vw;
-  } 
+  }
+
   .popupDrawer h4{
     font-size: 1rem;
     line-height: 1em;
@@ -235,7 +247,7 @@
     padding-left: 0;
     width: 100%;
   }
- 
+
   .popupDrawer .ppFilters  input{
     display: none;
   }
@@ -249,7 +261,7 @@
   {
       text-align: center;
       font-size: .7rem;
-      margin-top: 3rem;
+      margin-top: 1rem;
   }
 
   .popupDrawer .notice

--- a/frontend/webapp/src/views/_Common/ViewUtils.js
+++ b/frontend/webapp/src/views/_Common/ViewUtils.js
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react';
+import { detectScriptures } from "scripture-guide";
+import { Collapse } from 'bootstrap';
+
+// a react hook for detecting if a component is mounted
+export function useIsMounted() {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return isMounted?.current; // returning the ref, so we can access its current value
+}
+
+// a react hook for self clearing timeouts when component unmounts
+export function useTimeouts() {
+  const timeouts = useRef({});
+
+  const set = (key, callback, delay) => {
+    if (timeouts.current[key]) {
+      clearTimeout(timeouts.current[key]);
+    }
+    timeouts.current[key] = setTimeout(callback, delay);
+  };
+
+  const get = (key) => {
+    return timeouts.current[key];
+  }
+
+  const getAll = () => {
+    return timeouts.current;
+  }
+
+  const clear = (key) => {
+    if (timeouts.current[key]) {
+      clearTimeout(timeouts.current[key]);
+      delete timeouts.current[key];
+    }
+  };
+
+  const clearAll = () => {
+    Object.values(timeouts.current).forEach(clearTimeout);
+    timeouts.current = {};
+  };
+
+  useEffect(() => {
+    return clearAll; // clear all on unmount
+  }, []);
+
+  return { set, get, getAll, clear, clearAll };
+}
+
+
+export function getHtmlScriptureLinkParserOptions(clickHandler, additionalAttribs = {}) {
+    return {
+        replace: (domNode) => {
+          let {attribs} = domNode;
+            if (attribs?.classname === 'scripture_link') {
+                const ref = domNode.children[0].data;
+                attribs.class = attribs.classname;
+                delete attribs.classname;
+                attribs = {...attribs, ...additionalAttribs};
+                return <a {...attribs} onClick={()=>clickHandler(ref)}>{ref}</a>;
+            }
+        }
+    }
+};
+
+export function getDetectedScripturesHtml(html) {
+    return detectScriptures(html, (scripture) => {
+        if (!scripture) return;
+        return `<a className="scripture_link">${scripture}</a>`
+    });
+}


### PR DESCRIPTION
- Scriptures linked to fixed bottom of Mobile Drawer
  - Commentary, People, Places  
    <img width="377" alt="Screenshot 2024-05-22 at 11 39 22 PM" src="https://github.com/kckern/BookofMormonOnline/assets/849930/00dc7dfb-cbcb-4db6-89b0-f32b7cf712e6">

- Added `useIsMounted()` and `useTimeouts()` react hooks - the latter auto clears timeouts when components are unmounted
  - These can be used going forward to eliminate the following run-time error...
    - `Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application.`
  - Note that `CommentaryDrawer` has a sample usage of `useTimeouts`. We should start using this or something similar everywhere that a `setTimeout` exists in a react component.

- Added `.editorconfig` for editors that support it
  - Standardizes tabs/spaces
  - Cleans up white space over time so that PR diffs will be much cleaner - might be worth creating a single PR now that applies this to all files so that from now on white-space isn't an issue in diffs
    - Note how much of this PR is nothing but white space changes
  - We might also want to consider using a tool like prettier to standardize the formatting